### PR TITLE
More options for in-memory objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,9 +24,10 @@ Depends:
     R (>= 3.3.0),
     methods
 Imports:
-    Rcpp (>= 0.11.0)
+    Rcpp (>= 0.11.0),
+    float
 Suggests:
-    knitr, prettydoc
+    knitr, prettydoc, Matrix
 LinkingTo: Rcpp, RcppProgress
 VignetteBuilder: knitr
 RoxygenNote: 7.1.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,8 @@
 useDynLib(recosystem)
 import(methods)
 import(Rcpp)
+importClassesFrom(float,float32)
+importFrom(float,float)
 export(Reco)
 export(data_file, data_memory)
 export(out_file, out_memory, out_nothing)

--- a/R/RecoModel.R
+++ b/R/RecoModel.R
@@ -2,7 +2,8 @@ RecoModel = setRefClass("RecoModel",
                         fields = list(path  = "character",
                                       nuser = "integer",
                                       nitem = "integer",
-                                      nfac  = "integer"))
+                                      nfac  = "integer",
+                                      matrices = "list"))
 
 RecoModel$methods(
     initialize = function()
@@ -11,6 +12,7 @@ RecoModel$methods(
         .self$nuser = 0L
         .self$nitem = 0L
         .self$nfac  = 0L
+        .self$matrices = list()
     }
 )
 
@@ -24,5 +26,8 @@ RecoModel$methods(
         catl("Number of users",    .self$nuser)
         catl("Number of items",    .self$nitem)
         catl("Number of factors",  .self$nfac)
+
+        if (length(.self$matrices))
+            cat("(Contains model matrices in-memory)")
     }
 )

--- a/man/output.Rd
+++ b/man/output.Rd
@@ -40,7 +40,8 @@ r$output(out_P = data_file("mat_P.txt"), out_Q = data_file("mat_Q.txt"))}
 train_set = system.file("dat", "smalltrain.txt", package = "recosystem")
 r = Reco()
 set.seed(123) # This is a randomized algorithm
-r$train(data_file(train_set), opts = list(dim = 10, nmf = TRUE))
+r$train(data_file(train_set), file.path(tempdir(), "model.txt"),
+        opts = list(dim = 10, nmf = TRUE))
 
 ## Write P and Q matrices to files
 P_file = out_file(tempfile())

--- a/man/predict.Rd
+++ b/man/predict.Rd
@@ -6,9 +6,18 @@
 \arguments{
 \item{r}{Object returned by \code{\link{Reco}()}.}
 
-\item{train_data}{An object of class "DataSource" that describes the source
+\item{test_data}{An object of class "DataSource" that describes the source
 of testing data, typically returned by function
-\code{\link{data_file}()} or \code{\link{data_memory}()}.}
+\code{\link{data_file}()} or \code{\link{data_memory}()}.
+
+Alternatively, can pass a sparse matrix from the `Matrix` package
+in triplets/COO format (class `dgTMatrix` if it has ratings/values,
+class `ngTMatrix` if it's binary), with users corresponding to rows
+and items corresponding to columns.
+
+If passing a sparse matrix, the results will be output as another
+sparse matrix with the values of the input replaced with those of
+the predictions.}
 
 \item{out_pred}{An object of class \code{Output} that specifies the
 output format of prediction, typically returned by function
@@ -19,7 +28,10 @@ file, \code{\link{out_memory}()} exports the vector of
 predicted values into the return value of \code{$predict()},
 and \code{\link{out_nothing}()} means the result will be
 neither returned nor written into a file (but computation will
-still be conducted).}
+still be conducted).
+
+If passing `NULL`, will output predictions to memory as if passing
+\code{\link{out_memory}()}.}
 }
 \description{
 This method is a member function of class "\code{RecoSys}"

--- a/man/train.Rd
+++ b/man/train.Rd
@@ -8,9 +8,16 @@
 
 \item{train_data}{An object of class "DataSource" that describes the source
 of training data, typically returned by function
-\code{\link{data_file}()} or \code{\link{data_memory}()}.}
+\code{\link{data_file}()} or \code{\link{data_memory}()}.
 
-\item{out_model}{Path to the model file that will be created.}
+Alternatively, can pass a sparse matrix from the `Matrix` package
+in triplets/COO format (class `dgTMatrix` if it has ratings/values,
+class `ngTMatrix` if it's binary), with users corresponding to rows
+and items corresponding to columns.}
+
+\item{out_model}{Path to the model file that will be created.
+If passing `NULL`, will hold the model matrices in-memory in the same object. The
+matrices can then be accessed under `r$model$matrices`.}
 
 \item{opts}{A number of parameters and options for the model training.
 See section \strong{Parameters and Options} for details.}
@@ -81,16 +88,25 @@ For one-class matrix factorization,
 train_set = system.file("dat", "smalltrain.txt", package = "recosystem")
 r = Reco()
 set.seed(123) # This is a randomized algorithm
-r$train(data_file(train_set),
+r$train(data_file(train_set), out_model = file.path(tempdir(), "saved_model.txt"),
         opts = list(dim = 20, costp_l2 = 0.01, costq_l2 = 0.01, nthread = 1)
 )
 
 ## Training model from data in memory
 train_df = read.table(train_set, sep = " ", header = FALSE)
 set.seed(123)
-r$train(data_memory(train_df[, 1], train_df[, 2], train_df[, 3]),
+r$train(data_memory(train_df[, 1], train_df[, 2], train_df[, 3]), out_model = NULL,
         opts = list(dim = 20, costp_l2 = 0.01, costq_l2 = 0.01, nthread = 1)
 )
+
+## Using sparse matrix objects
+if (require(Matrix)) {
+    X = Matrix::sparseMatrix(i=train_df[, 1], j=train_df[, 2], x=train_df[, 3],
+                             repr="T", index1=FALSE)
+    r$train(X, out_model=NULL,
+            opts = list(dim = 20, costp_l2 = 0.01, costq_l2 = 0.01, nthread = 1))
+}
+
 
 }
 \references{

--- a/man/tune.Rd
+++ b/man/tune.Rd
@@ -8,7 +8,12 @@
 
 \item{train_data}{An object of class "DataSource" that describes the source
 of training data, typically returned by function
-\code{\link{data_file}()} or \code{\link{data_memory}()}.}
+\code{\link{data_file}()} or \code{\link{data_memory}()}.
+
+Alternatively, can pass a sparse matrix from the `Matrix` package
+in triplets/COO format (class `dgTMatrix` if it has ratings/values,
+class `ngTMatrix` if it's binary), with users corresponding to rows
+and items corresponding to columns.}
 
 \item{opts}{A number of candidate tuning parameter values and extra options in the
 model tuning procedure. See section \strong{Parameters and Options}

--- a/src/register_routines.c
+++ b/src/register_routines.c
@@ -4,7 +4,7 @@ static R_CallMethodDef callMethods[] = {
     {"reco_tune",    (DL_FUNC) &reco_tune,    3},
     {"reco_train",   (DL_FUNC) &reco_train,   3},
     {"reco_output",  (DL_FUNC) &reco_output,  3},
-    {"reco_predict", (DL_FUNC) &reco_predict, 3},
+    {"reco_predict", (DL_FUNC) &reco_predict, 4},
     {NULL, NULL, 0}
 };
 

--- a/src/register_routines.h
+++ b/src/register_routines.h
@@ -9,7 +9,7 @@
 SEXP reco_tune(SEXP train_data_, SEXP opts_tune_, SEXP opts_other_);
 SEXP reco_train(SEXP train_data_, SEXP model_path_, SEXP opts_);
 SEXP reco_output(SEXP model_path_, SEXP P_, SEXP Q_);
-SEXP reco_predict(SEXP test_data_, SEXP model_path_, SEXP output_);
+SEXP reco_predict(SEXP test_data_, SEXP model_path_, SEXP output_, SEXP model_inmemory_);
 
 
 #endif


### PR DESCRIPTION
This PR introduces several changes in order to work better with in-memory data:
* Makes the functions accept sparse matrix objects as inputs.
* Leaves the option to store the fitted matrices in the model object in memory instead of creating a file, and access them directly for easier retrieval.
* Changes the default options for some arguments to avoid accidentally creating files where it's not intended.
